### PR TITLE
Lazy load voice class & Add database support for aoi.mongo

### DIFF
--- a/src/classes/Database.js
+++ b/src/classes/Database.js
@@ -278,6 +278,9 @@ class AoiMongoDb extends Database {
     }
 
     async roundTrip() {
+        await this.preClient
+        if (this.error) throw this.error
+
         const before = Date.now()
         await this.db.command({ ping: 1 })
 

--- a/src/classes/Database.js
+++ b/src/classes/Database.js
@@ -234,14 +234,14 @@ class AoiMongoDb extends Database {
         return !!res.upsertedCount || !!res.modifiedCount
     }
 
-    async get(table, name, id, value) {
+    async get(table, name, id) {
         await this.preClient
         if (this.error) throw this.error
 
         const mongo = this.collections.get(table)
         const key = `${name}_${id}`
 
-        return mongo.get(key, value)
+        return mongo.get(key)
     }
 
     async all(table, varName, lengthOfId, funcOnId) {

--- a/src/classes/base.js
+++ b/src/classes/base.js
@@ -10,7 +10,7 @@ const {
     IntentOptions,
     SlashOptionTypes,
 } = require("../utils/Constants.js");
-const {AoijsAPI, DbdTsDb, CustomDb, Promisify} = require("./Database.js");
+const {AoijsAPI, DbdTsDb, AoiMongoDb, CustomDb, Promisify} = require("./Database.js");
 const CacheManager = require("./CacheManager.js");
 const {CommandManager} = require("./Commands.js");
 
@@ -99,6 +99,16 @@ class BaseClient extends Discord.Client {
                 {type: "dbdts.db", promisify: false},
                 options.database?.extraOptions || {},
             );
+        } else if (options?.database?.type === "aoi.mongo") {
+            this.db = new AoiMongoDb(
+                options.database?.db,
+                {
+                    path: options.database?.path,
+                    tables: options.database?.tables || ["main"]
+                },
+                { type: "aoi.mongo", promisify: true },
+                { ...AoiMongoDb.defaultOptions, ...(options.database?.extraOptions || {}) }
+            )
         } else if (
             options?.database?.type === "custom" &&
             !options?.database?.promisify

--- a/src/functions/Funcs/info/dbPing.js
+++ b/src/functions/Funcs/info/dbPing.js
@@ -1,7 +1,8 @@
 module.exports = async d => {
     const {code} = d.util.openFunc(d);
+    const ping = d.client.db.roundTrip ? await d.client.db.roundTrip() : d.client.db.ping
 
     return {
-        code: d.util.setCode({function: d.func, code, result: d.client.db.ping})
+        code: d.util.setCode({function: d.func, code, result: ping})
     }
 }

--- a/src/functions/Funcs/info/dbPing.js
+++ b/src/functions/Funcs/info/dbPing.js
@@ -1,6 +1,13 @@
 module.exports = async d => {
     const {code} = d.util.openFunc(d);
-    const ping = d.client.db.roundTrip ? await d.client.db.roundTrip() : d.client.db.ping
+
+    let ping
+
+    if (d.client.db.roundTrip) {
+        ping = await d.client.db.roundTrip()
+    } else {
+        ping = d.client.db.ping
+    }
 
     return {
         code: d.util.setCode({function: d.func, code, result: ping})

--- a/src/functions/Funcs/misc/globalUserLeaderBoard.js
+++ b/src/functions/Funcs/misc/globalUserLeaderBoard.js
@@ -1,4 +1,4 @@
-const {AoijsAPI, DbdTsDb, Promisify, CustomDb} = require("../../../classes/Database.js");
+const {AoijsAPI, DbdTsDb, AoiMongoDb, Promisify, CustomDb} = require("../../../classes/Database.js");
 
 module.exports = async d => {
     const Data = d.util.openFunc(d);
@@ -17,6 +17,8 @@ module.exports = async d => {
             return (Number(y.data.value) - Number(x.data.value))
         } else if (d.client.db instanceof DbdTsDb) {
             return (Number(y[variable.addBrackets()]) - Number(x[variable.addBrackets()]));
+        } else if (d.client.db instanceof AoiMongoDb) {
+            return (Number(y.value) - Number(x.value))
         } else if (d.client.db instanceof CustomDb || d.client.db instanceof Promisify) {
             return (Number(y.value || y[variable.addBrackets()] || (typeof y.data === 'object' ? y.data.value : y.data)) - Number(x.value || x[variable.addBrackets()] || (typeof x.data === 'object' ? x.data.value : x.data)))
         }
@@ -31,6 +33,10 @@ module.exports = async d => {
             value = Number(data[variable.addBrackets()]);
 
             user = await d.util.getUser(d, data.key.split('_')[0])
+        } else if (d.client.db instanceof AoiMongoDb) {
+            value = Number(data.value)
+
+            user = await d.util.getUser(d, data.key.split('_')[1])
         } else if (d.client.db instanceof CustomDb || d.client.db instanceof Promisify) {
             value = Number(data.value || data[variable.addBrackets()] || (typeof data.data === 'object' ? data.data.value : data.data))
 
@@ -55,7 +61,7 @@ module.exports = async d => {
         if (user) {
             y++
 
-            let text = custom.replace(`{top}`, y).replace("{id}", user.id).replace("{tag}", user.tag).replace(`{username}`, user.username.removeBrackets()).replace(`{value}`, Number(data.data.value))
+            let text = custom.replace(`{top}`, y).replace("{id}", user.id).replace("{tag}", user.tag).replace(`{username}`, user.username.removeBrackets()).replace(`{value}`, value)
 
             if (text.includes("{execute:")) {
                 let ins = text.split("{execute:")[1].split("}")[0]

--- a/src/functions/Funcs/misc/rawLeaderboard.js
+++ b/src/functions/Funcs/misc/rawLeaderboard.js
@@ -1,4 +1,4 @@
-const {AoijsAPI, DbdTsDb, CustomDb, Promisify} = require("../../../classes/Database.js");
+const {AoijsAPI, DbdTsDb, AoiMongoDb, CustomDb, Promisify} = require("../../../classes/Database.js");
 
 module.exports = async d => {
     const Data = d.util.openFunc(d);
@@ -19,6 +19,8 @@ module.exports = async d => {
             return (Number(y.data.value) - Number(x.data.value))
         } else if (d.client.db instanceof DbdTsDb) {
             return (Number(y[variable.addBrackets()]) - Number(x[variable.addBrackets()]));
+        } else if (d.client.db instanceof AoiMongoDb) {
+            return (Number(y.value) - Number(x.value))
         } else if (d.client.db instanceof CustomDb || d.client.db instanceof Promisify) {
             return (Number(y.value || y[variable.addBrackets()] || (typeof y.data === 'object' ? y.data.value : y.data)) - Number(x.value || x[variable.addBrackets()] || (typeof x.data === 'object' ? x.data.value : x.data)))
         }
@@ -32,6 +34,10 @@ module.exports = async d => {
             value = Number(data[variable.addBrackets()]);
 
             user = await getData(user, data, 0);
+        } else if (d.client.db instanceof AoiMongoDb) {
+            value = Number(data.value)
+
+            user = await getData(user, data, 1)
         } else if (d.client.db instanceof CustomDb || d.client.db instanceof Promisify) {
             value = Number(data.value || data[variable.addBrackets()] || (typeof data.data === 'object' ? data.data.value : data.data))
 

--- a/src/functions/Funcs/misc/serverLeaderBoard.js
+++ b/src/functions/Funcs/misc/serverLeaderBoard.js
@@ -4,7 +4,7 @@ module.exports = async d => {
     const Data = d.util.openFunc(d);
     if (Data.err) return d.error(Data.err)
 
-    const [variable, type = 'asc', custom = `{top}) {name} : {value}`, list = 10, page = 1, table = d.client.db.tables[0]] = Data.inside.splits;
+    const [variable, type = 'asc', custom = `{top}) {username} : {value}`, list = 10, page = 1, table = d.client.db.tables[0]] = Data.inside.splits;
 
     const all = await d.client.db.all(table, variable.addBrackets(), 1)
 

--- a/src/functions/Funcs/misc/serverLeaderBoard.js
+++ b/src/functions/Funcs/misc/serverLeaderBoard.js
@@ -1,10 +1,10 @@
-const {AoijsAPI, DbdTsDb, Promisify, CustomDb} = require("../../../classes/Database.js");
+const {AoijsAPI, DbdTsDb, AoiMongoDb, Promisify, CustomDb} = require("../../../classes/Database.js");
 
 module.exports = async d => {
     const Data = d.util.openFunc(d);
     if (Data.err) return d.error(Data.err)
 
-    const [variable, type = 'asc', custom = `{top}) {username} : {value}`, list = 10, page = 1, table = d.client.db.tables[0]] = Data.inside.splits;
+    const [variable, type = 'asc', custom = `{top}) {name} : {value}`, list = 10, page = 1, table = d.client.db.tables[0]] = Data.inside.splits;
 
     const all = await d.client.db.all(table, variable.addBrackets(), 1)
 
@@ -17,6 +17,8 @@ module.exports = async d => {
             return (Number(y.data.value) - Number(x.data.value))
         } else if (d.client.db instanceof DbdTsDb) {
             return (Number(y[variable.addBrackets()]) - Number(x[variable.addBrackets()]));
+        } else if (d.client.db instanceof AoiMongoDb) {
+            return (Number(y.value) - Number(x.value))
         } else if (d.client.db instanceof CustomDb || d.client.db instanceof Promisify) {
             return (Number(y.value || y[variable.addBrackets()] || (typeof y.data === 'object' ? y.data.value : y.data)) - Number(x.value || x[variable.addBrackets()] || (typeof x.data === 'object' ? x.data.value : x.data)))
         }
@@ -30,6 +32,10 @@ module.exports = async d => {
             value = Number(data[variable.addBrackets()]);
 
             user = await d.util.getGuild(d, data.key.split('_')[0])
+        } else if (d.client.db instanceof AoiMongoDb) {
+            value = Number(data.value)
+
+            user = await d.util.getGuild(d, data.key.split('_')[1])
         } else if (d.client.db instanceof CustomDb || d.client.db instanceof Promisify) {
             value = Number(data.value || data[variable.addBrackets()] || (typeof data.data === 'object' ? data.data.value : data.data))
 

--- a/src/functions/Funcs/misc/userLeaderBoard.js
+++ b/src/functions/Funcs/misc/userLeaderBoard.js
@@ -1,4 +1,4 @@
-const {AoijsAPI, DbdTsDb, CustomDb, Promisify} = require("../../../classes/Database.js");
+const {AoijsAPI, DbdTsDb, AoiMongoDb, CustomDb, Promisify} = require("../../../classes/Database.js");
 
 module.exports = async d => {
     const Data = d.util.openFunc(d);
@@ -21,6 +21,8 @@ module.exports = async d => {
             return (Number(y.data.value) - Number(x.data.value))
         } else if (d.client.db instanceof DbdTsDb) {
             return (Number(y[variable.addBrackets()]) - Number(x[variable.addBrackets()]));
+        } else if (d.client.db instanceof AoiMongoDb) {
+            return (Number(y.value) - Number(x.value))
         } else if (d.client.db instanceof CustomDb || d.client.db instanceof Promisify) {
             return (Number(y.value || y[variable.addBrackets()] || (typeof y.data === 'object' ? y.data.value : y.data)) - Number(x.value || x[variable.addBrackets()] || (typeof x.data === 'object' ? x.data.value : x.data)))
         }
@@ -34,6 +36,10 @@ module.exports = async d => {
             value = Number(data[variable.addBrackets()]);
 
             user = await d.util.getMember(guild, data.key.split('_')[0])
+        } else if (d.client.db instanceof AoiMongoDb) {
+            value = Number(data.value)
+
+            user = await d.util.getMember(guild, data.key.split('_')[1])
         } else if (d.client.db instanceof CustomDb || d.client.db instanceof Promisify) {
             value = Number(data.value || data[variable.addBrackets()] || (typeof data.data === 'object' ? data.data.value : data.data))
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,22 @@ const Client = require("./classes/Bot.js");
 const CustomEvent = require("./classes/NewEvent.js");
 const LoadCommands = require("./classes/LoadCommands.js");
 const ClientShard = require("./classes/ClientShard.js");
-const Voice = require("./classes/Voice.js");
 const Lavalink = require("./classes/Lavalink.js");
 const AoiError = require("./classes/AoiError.js");
 const Util = require("./classes/Util.js");
+
+let Voice;
+
+try {
+    Voice = require("./classes/Voice.js");
+} catch (err) {
+    Voice = class {
+        constructor() {
+            throw err;
+        }
+    }
+}
+
 module.exports = {
     /**
      * * The Discord Bot Client


### PR DESCRIPTION
## Type
- [ ] Bug Fix
- [ ] Functions: \<Function Name>
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [x] Others:
  - Lazy load voice class
  - Add database support for aoi.mongo

Dependencies (Third Party Modules) needed: <Name | Github Link> (Maximum: 20MB~ size)

Want a credit? Discord tag or other social media link: <DiscordTag | OtherSocialMediaLink>

Referenced Issue: #NaN (Answer for an issue, if any)

## Description
- Lazy load voice class so it will only return error when constructed
- Add database support for aoi.mongo
  How to use:
    - Install `mongodb`
    - Install `aoi.mongo`
    - Example setup:
      where `prefix` is the bot prefix and `mongo cluster url` is the mongodb cluster url like
      
      `mongodb+srv://<username>:<password>@<???>.<???>.mongodb.net/?w=majority&retryWrites=true`
      ```js
      const aoijs = require("aoi.js")
      const aoimongo = require("aoi.mongo")
      
      const bot = new aoijs.Bot({
        token: process.env.TOKEN,
        prefix: "prefix",
        intents: "all",
        database: {
          db: aoimongo,
          type: "aoi.mongo",
          path: "mongo cluster url"
        }
      })
      
      // ...
      ```
