### PR TITLE
Add database support for aoi.fb (A Firebase database of wrapper using aoi.fb as API)

### DIFF
--- a/src/classes/AoiBase.js
+++ b/src/classes/AoiBase.js
@@ -73,7 +73,7 @@ class BaseClient extends Discord.Client {
         }
 
         if (
-            ["default", "dbdjs.db", "dbdjs.db-sql", "dbdjs.mongo"].includes(
+            ["default", "dbdjs.db", "dbdjs.db-sql", "dbdjs.mongo", "aoi.fb"].includes(
                 options?.database?.type,
             )
         ) {

--- a/src/classes/Database.js
+++ b/src/classes/Database.js
@@ -90,6 +90,8 @@ class AoijsAPI extends Database {
         } else if (type === "dbdjs.mongo") {
             this.db = this.module.default;
             this.tables.forEach((x) => this.db.createModel(x));
+        } else if (type === "aoi.fb") {
+            this.db = this.module;
         } else if (type === "dbdjs.db-sql") {
             this.db = this.module.PromisedDatabase(
                 this.path.replace("./", "") + "/database.sql",


### PR DESCRIPTION
## Type
- [ ] Bug Fix
- [ ] Functions: \<Function Name>
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [x] Others: \______
  - Add database support for aoi.fb (A Firebase database of wrapper using aoi.fb as API)

Dependencies (Third Party Modules) needed: < aoi.fb| https://github.com/aoifb/aoi.fb >

Want a credit? Discord tag or other social media link: < `GR#3012` >

## Description
- Add database support for aoi.fb (A Firebase database of wrapper using aoi.fb as API)
  How to use:
- Install `aoi.fb`
- Example setup:

```js
const aoifb = require("aoi.fb")

const firebase = aoifb.Create({
  apiKey: "",
  authDomain: "",
  databaseURL: "",
  projectId: "",
  storageBucket: "",
  messagingSenderId: "",
  appId: "",
  measurementId: ""
})

const aoijs = require("aoi.js")

const bot = new aoijs.Bot({
  token: "TOKEN", // Discord Bot Token
  prefix: "PREFIX",// Discord Bot Prefix
  intents: ["GUILDS", "GUILD_MESSAGES"], // Discord Bot Intents
  database: {
    type: "aoi.fb",
    db: firebase
  } // Change database to aoi.fb
})
```