### PR TITLE
Add database support for aoi.fb (Database.js)

### DIFF
--- a/package/classes/Database.js
+++ b/package/classes/Database.js
@@ -49,8 +49,9 @@ class DbdjsApi extends Database{
         else if(type === "dbdjs.mongo"){
       this.db = this.module.default    
 this.tables.forEach(x=>this.db.createModel(x))
-        }
-        else if(type === "dbdjs.db-sql"){
+        } else if (type === "aoi.fb") {
+            this.db = this.module;
+        } else if(type === "dbdjs.db-sql"){
             this.db = this.module.PromisedDatabase(this.path.replace("./","")+"/database.sql",this.extraOptions.sqlOptions||{timeout:5000}) 
 
         }


### PR DESCRIPTION
## Type
- [ ] Bug Fix
- [ ] Functions: \<Function Name>
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [x] Others: \______
  - Add database support for aoi.fb (A Firebase database of wrapper using aoi.fb as API)

Dependencies (Third Party Modules) needed: < aoi.fb| https://github.com/MiraiDevelopment/aoi.fb >

Want a credit? Discord tag or other social media link: < `GR#6553` >

## Description
- Add database support for aoi.fb (A Firebase database of wrapper using aoi.fb as API)
  How to use:
- Install `aoi.fb`
- Example setup:

```js
const aoifb = require("aoi.fb")

const firebase = aoifb.Create({
  apiKey: "",
  authDomain: "",
  databaseURL: "",
  projectId: "",
  storageBucket: "",
  messagingSenderId: "",
  appId: "",
  measurementId: ""
})

import { AoiClient } from "aoi.js";

const bot = new AoiClient({
    token: "DISCORD BOT TOKEN",
    intents: ["guilds", "guildMessages"],
    prefix: "DISCORD BOT PREFIX",
    database: {
        type: "aoi.fb",
        db: firebase
    } // Change database to aoi.fb
})

bot.addEvent("onMessage")

bot.commands.add("basicCommand", {
    name: "ping",
    code: `
> Bot Latency: $pingms
> Database Latency: $djsEval[client.db.db.ping();yes]`
})

bot.start()
```