### PR TITLE
refactor: time functions with padding by default

### DIFF
--- a/src/functions/misc/hour.js
+++ b/src/functions/misc/hour.js
@@ -1,11 +1,11 @@
-const {FormatOptions} = require("../../utils/Constants");
+const { FormatOptions } = require("../../utils/Constants");
 
 module.exports = (d) => {
     const data = d.util.aoiFunc(d);
-    const date = new Date(new Date().toLocaleString('en-us', { timeZone: d.timezone }));
+    const date = new Date(new Date().toLocaleString("en-us", { timeZone: d.timezone }));
     const formattedOptions = FormatOptions(date);
 
-    data.result = formattedOptions.H;
+    data.result = formattedOptions.HH;
 
     return {
         code: d.util.setCode(data)

--- a/src/functions/misc/minute.js
+++ b/src/functions/misc/minute.js
@@ -1,7 +1,9 @@
 module.exports = d => {
     const data = d.util.aoiFunc(d);
 
-    data.result = new Date(new Date().toLocaleString('en-us', {timeZone: d.timezone})).getMinutes();
+    const minutes = new Date(new Date().toLocaleString("en-us", { timeZone: d.timezone })).getMinutes();
+    data.result = String(minutes).padStart(2, "0");
+    
     return {
         code: d.util.setCode(data)
     }

--- a/src/functions/misc/second.js
+++ b/src/functions/misc/second.js
@@ -1,9 +1,11 @@
-module.exports = d => {
-    const data = d.util.aoiFunc(d);
 
-    data.result = new Date(new Date().toLocaleString('en-us', {timeZone: d.timezone})).getSeconds();
+module.exports = (d) => {
+    const data = d.util.aoiFunc(d);
+    
+    const seconds = new Date(new Date().toLocaleString("en-us", { timeZone: d.timezone })).getSeconds();
+    data.result = String(seconds).padStart(2, "0");
 
     return {
         code: d.util.setCode(data)
-    }
-}
+    };
+};


### PR DESCRIPTION
## Type
- [x] Functions: Modifies existing functions

## Description
Make padding for time functions default.

This was requested somewhen in the discord server

Unsure if we should add ss, mm and others to constants like HH would resolve inconsitency, but would become an issue with MM (months).